### PR TITLE
Pin vLLM version

### DIFF
--- a/compose/docker-compose.eager.yml
+++ b/compose/docker-compose.eager.yml
@@ -25,7 +25,7 @@
 # ===========================================================================
 services:
   vllm-qwen36-27b-eager:
-    image: vllm/vllm-openai:nightly
+    image: vllm/vllm-openai:nightly-100c7b65e7579c8caf4ee0b04a6410b2796b905c
     container_name: vllm-qwen36-27b-eager
     restart: "no"
     ports:

--- a/compose/docker-compose.minimal.yml
+++ b/compose/docker-compose.minimal.yml
@@ -22,7 +22,7 @@
 # ===========================================================================
 services:
   vllm-qwen36-27b-minimal:
-    image: vllm/vllm-openai:nightly
+    image: vllm/vllm-openai:nightly-100c7b65e7579c8caf4ee0b04a6410b2796b905c
     container_name: vllm-qwen36-27b-minimal
     restart: "no"
     ports:

--- a/compose/docker-compose.v714.yml
+++ b/compose/docker-compose.v714.yml
@@ -41,7 +41,7 @@
 # ===========================================================================
 services:
   vllm-qwen36-27b:
-    image: vllm/vllm-openai:nightly
+    image: vllm/vllm-openai:nightly-100c7b65e7579c8caf4ee0b04a6410b2796b905c
     container_name: vllm-qwen36-27b
     restart: "no"
     ports:


### PR DESCRIPTION
Pinned the version that works

I test it on the docker-compose.v714.yml

i ran the docker yesterday, it worked
but today it didnt

Also noticed that there is new docker entries
https://hub.docker.com/r/vllm/vllm-openai/tags?name=nightly

<img width="2940" height="1844" alt="CleanShot 1447-11-10 at 16 10 42@2x" src="https://github.com/user-attachments/assets/d24607b2-c1aa-4e9f-9cc1-b59c8888518d" />


So yeah just pinned it to the one before 3 days and now it works

